### PR TITLE
fix: use non interactive agents

### DIFF
--- a/internal/agents/detector.go
+++ b/internal/agents/detector.go
@@ -52,8 +52,8 @@ func NewDetector() (*Detector, error) {
 		agents: []Agent{
 			{Type: GeminiCLI, Name: "Gemini CLI", Command: "gemini"},
 			{Type: ClaudeCode, Name: "Claude Code", Command: "claude"},
-			{Type: OpenAICodex, Name: "OpenAI Codex", Command: "openai"},
-			{Type: GitHubCLI, Name: "GitHub Copilot CLI", Command: "gh"},
+			{Type: OpenAICodex, Name: "OpenAI Codex", Command: "codex"},
+			{Type: GitHubCLI, Name: "GitHub Copilot CLI", Command: "gh copilot"},
 		},
 		templateEngine: templateEngine,
 	}, nil
@@ -152,7 +152,7 @@ func (d *Detector) executeGemini(prompt string, targetDir string) error {
 }
 
 func (d *Detector) executeClaude(prompt string, targetDir string) error {
-	cmd := exec.Command("claude", "code", prompt)
+	cmd := exec.Command("claude", "-p", prompt)
 	cmd.Dir = targetDir
 	cmd.Stdout = nil
 	cmd.Stderr = nil
@@ -160,7 +160,7 @@ func (d *Detector) executeClaude(prompt string, targetDir string) error {
 }
 
 func (d *Detector) executeOpenAI(prompt string, targetDir string) error {
-	cmd := exec.Command("openai", "api", "completions.create", "-p", prompt)
+	cmd := exec.Command("codex", prompt)
 	cmd.Dir = targetDir
 	cmd.Stdout = nil
 	cmd.Stderr = nil


### PR DESCRIPTION
This pull request updates the agent configuration and command execution logic in the `Detector` to better align with the actual CLI commands used for each agent. The changes ensure that the correct command-line interfaces are invoked for OpenAI Codex, GitHub Copilot CLI, and Claude Code agents.

**Agent configuration updates:**

* Changed the command for `OpenAICodex` from `"openai"` to `"codex"` in the agent list, ensuring the detector invokes the correct CLI for Codex.
* Changed the command for `GitHubCLI` from `"gh"` to `"gh copilot"` in the agent list, specifying the proper subcommand for Copilot operations.

**Agent command execution updates:**

* Updated the Claude Code execution to use the `-p` flag for prompts instead of the previous `"code"` subcommand, reflecting the correct CLI usage.
* Simplified the OpenAI Codex execution to directly call `"codex"` with the prompt, removing unnecessary arguments and switching from the `"openai"` CLI.